### PR TITLE
Make Prettier use `xml` instead of the `html` parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
                 "yargs": "^17.5.1"
             },
             "devDependencies": {
+                "@prettier/plugin-xml": "^2.2.0",
                 "@types/jest": "^27.5.1",
                 "esbuild-jest": "^0.5.0",
                 "jest": "^28.1.0",
@@ -1120,6 +1121,16 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@prettier/plugin-xml": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-2.2.0.tgz",
+            "integrity": "sha512-UWRmygBsyj4bVXvDiqSccwT1kmsorcwQwaIy30yVh8T+Gspx4OlC0shX1y+ZuwXZvgnafmpRYKks0bAu9urJew==",
+            "dev": true,
+            "dependencies": {
+                "@xml-tools/parser": "^1.0.11",
+                "prettier": ">=2.4.0"
+            }
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.23.5",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
@@ -1305,6 +1316,15 @@
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
+        },
+        "node_modules/@xml-tools/parser": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+            "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+            "dev": true,
+            "dependencies": {
+                "chevrotain": "7.1.1"
+            }
         },
         "node_modules/acorn": {
             "version": "8.7.1",
@@ -1813,6 +1833,15 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chevrotain": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+            "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+            "dev": true,
+            "dependencies": {
+                "regexp-to-ast": "0.5.0"
             }
         },
         "node_modules/ci-info": {
@@ -5736,6 +5765,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/regexp-to-ast": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+            "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+            "dev": true
+        },
         "node_modules/remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -8315,6 +8350,16 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "@prettier/plugin-xml": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-2.2.0.tgz",
+            "integrity": "sha512-UWRmygBsyj4bVXvDiqSccwT1kmsorcwQwaIy30yVh8T+Gspx4OlC0shX1y+ZuwXZvgnafmpRYKks0bAu9urJew==",
+            "dev": true,
+            "requires": {
+                "@xml-tools/parser": "^1.0.11",
+                "prettier": ">=2.4.0"
+            }
+        },
         "@sinclair/typebox": {
             "version": "0.23.5",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
@@ -8500,6 +8545,15 @@
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
+        },
+        "@xml-tools/parser": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+            "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+            "dev": true,
+            "requires": {
+                "chevrotain": "7.1.1"
+            }
         },
         "acorn": {
             "version": "8.7.1",
@@ -8860,6 +8914,15 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
             "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+        },
+        "chevrotain": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+            "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+            "dev": true,
+            "requires": {
+                "regexp-to-ast": "0.5.0"
+            }
         },
         "ci-info": {
             "version": "3.3.1",
@@ -11741,6 +11804,12 @@
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
             }
+        },
+        "regexp-to-ast": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+            "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+            "dev": true
         },
         "remove-trailing-separator": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
+        "@prettier/plugin-xml": "^2.2.0",
         "@types/jest": "^27.5.1",
         "esbuild-jest": "^0.5.0",
         "jest": "^28.1.0",

--- a/scripts/generate-typescript.ts
+++ b/scripts/generate-typescript.ts
@@ -53,7 +53,7 @@ async function main(grammarFile: string, outDir: string) {
     // Write out the intermediate (simplified) XML
     const formattedXml = Prettier.format(toXml(ast), { parser: "html" });
     const xmlOutFile = path.join(outDir, "simplified-grammar.xml");
-    origLog(chalk.red("Writing JSON grammar to", xmlOutFile));
+    origLog(chalk.red("Writing simplified grammar to", xmlOutFile));
     await fs.writeFile(xmlOutFile, formattedXml, "utf-8");
 
     const grammarTypes = makeTypesForGrammar(ast.children[0]);

--- a/scripts/generate-typescript.ts
+++ b/scripts/generate-typescript.ts
@@ -51,7 +51,7 @@ async function main(grammarFile: string, outDir: string) {
     ast = unifiedXml().use(renameRefsPlugin).runSync(ast);
 
     // Write out the intermediate (simplified) XML
-    const formattedXml = Prettier.format(toXml(ast), { parser: "html" });
+    const formattedXml = Prettier.format(toXml(ast), { parser: "xml" });
     const xmlOutFile = path.join(outDir, "simplified-grammar.xml");
     origLog(chalk.red("Writing simplified grammar to", xmlOutFile));
     await fs.writeFile(xmlOutFile, formattedXml, "utf-8");


### PR DESCRIPTION
Note that the formatting kinda sucks because the XML plugin preserves all whitespace, or lack of thereof, between tags. `xmlWhitespaceSensitivity: "ignore"` results in a better looking file, but also changes the content of text nodes by inserting whitespace. The upcoming `xmlWhitespaceSensitivity: "preserve"` would've been the best, and would replicate the `html` parser's behavior. Closes #1